### PR TITLE
[GH-671] add editorial notices to tally widget

### DIFF
--- a/src/components/Count.js
+++ b/src/components/Count.js
@@ -11,7 +11,13 @@ export const Count = ({ className, horizontal, type, count, showLabels = false }
       })
     }
   >
-    {showLabels && <span className={styles.label}>{type}</span>}
+    {showLabels && (
+      type === 'notices' ?
+        <span className={styles.label}>editorial notices</span>
+      : (
+        <span className={styles.label}>{type}</span>
+      )
+    )}
 
     <div
       className={

--- a/src/components/Tally.js
+++ b/src/components/Tally.js
@@ -29,7 +29,7 @@ class Tally extends Component {
   }
 
   render () {
-    const { horizontal, showZero, showLabels, tally } = this.props
+    const { horizontal, showZero, showLabels, tally,  notices, showNotices } = this.props
     const classes = {
       tally: classNames('scite-tally', styles.tally, {
         [styles.horizontal]: horizontal,
@@ -50,6 +50,7 @@ class Tally extends Component {
         <Count type='supporting' count={supporting} horizontal={horizontal} showLabels={showLabels} />
         <Count type='mentioning' count={mentioning} horizontal={horizontal} showLabels={showLabels} />
         <Count type='disputing' count={disputing} horizontal={horizontal} showLabels={showLabels} />
+        {showNotices && notices && notices.length > 0 && <Count type='notices' horizontal={horizontal} showLabels={showLabels} />}
       </div>
     )
   }
@@ -58,7 +59,8 @@ class Tally extends Component {
 Tally.defaultProps = {
   horizontal: false,
   isBadge: false,
-  showZero: true
+  showZero: true,
+  showNotices: true,
 }
 
 export default Tally

--- a/src/components/TallyLoader.js
+++ b/src/components/TallyLoader.js
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react'
 
 const { fetch } = window
 
-function fetchReport ({ doi, setTally, setError, retry = 0, maxRetries = 8 } = {}) {
+function fetchTally ({ doi, setTally, setError, retry = 0, maxRetries = 8 } = {}) {
   const fetchFailed = new Error('Failed to get Tally')
   fetch(`https://api.scite.ai/tallies/${doi}`)
     .then(response => {
@@ -37,12 +37,45 @@ function fetchReport ({ doi, setTally, setError, retry = 0, maxRetries = 8 } = {
     })
 }
 
+function fetchNotices ({ doi, setNotices, setError, retry = 0, maxRetries = 8 } = {}) {
+  const fetchFailed = new Error('Failed to get notices')
+  fetch(`http://localhost:8000/papers/${doi}`)
+    .then(response => {
+      if (response.status === 404) {
+        // Then we will set a notices to []
+        setNotices([])
+
+        return {}
+      }
+
+      if (!response.ok) {
+        throw fetchFailed
+      }
+
+      return response.json()
+    })
+    .then(({ editorialNotices }) => {
+      setNotices(editorialNotices)
+    })
+    .catch(e => {
+      if (e === fetchFailed && retry < maxRetries) {
+        return setTimeout(() => this.fetchReport(++retry, maxRetries), 1200)
+      }
+
+      setError(e)
+    })
+}
+
 export const TallyLoader = ({ doi, children }) => {
   const [tally, setTally] = useState(null)
+  const [notices, setNotices] = useState(null)
   const [error, setError] = useState(null)
-  useEffect(() => fetchReport({ doi, setTally, setError }), [doi])
+  useEffect(() => {
+    fetchTally({ doi, setTally, setError })
+    fetchNotices({ doi, setNotices, setError })
+  }, [doi])
 
-  return children({ tally, error })
+  return children({ tally, notices, error })
 }
 
 export default TallyLoader

--- a/src/styles/Icon.css
+++ b/src/styles/Icon.css
@@ -27,3 +27,8 @@
     content: "\e903";
     color: #2ECC71;
 }
+
+.notices:before {
+    content: "\e901";
+    color: #FF3B30;
+}

--- a/stories/Count.stories.js
+++ b/stories/Count.stories.js
@@ -11,6 +11,7 @@ const Template = (args) => <>
   <Count type='supporting' count={50} {...args} />
   <Count type='mentioning' count={50} {...args} />
   <Count type='disputing' count={50}  {...args} />
+  <Count type='notices'  {...args} />
 </>;
 
 export const Basic = Template.bind({});

--- a/stories/Tally.stories.js
+++ b/stories/Tally.stories.js
@@ -15,6 +15,7 @@ const tally = {
 
 const Template = (args) => <Tally
   tally={tally}
+  notices={[{'status': 'retracted'}]}
   {...args}
 />;
 

--- a/stories/TallyLoader.stories.js
+++ b/stories/TallyLoader.stories.js
@@ -7,8 +7,15 @@ export default {
   component: TallyLoader,
 };
 
-const Template = (args) => <TallyLoader doi='10.1016/j.biopsych.2005.08.012'>
-    {({ tally }) => <Tally tally={tally} />}
+const Template = (args) => <TallyLoader {...args}>
+    {({ tally, notices }) => <Tally tally={tally} notices={notices} />}
   </TallyLoader>;
 
 export const TallyLoaded = Template.bind({});
+TallyLoaded.args = {
+  doi: '10.1016/j.biopsych.2005.08.012'
+}
+export const TallyLoadedRetractionNotice = Template.bind({});
+TallyLoadedRetractionNotice.args = {
+  doi: '10.1371/journal.ppat.0020025'
+}


### PR DESCRIPTION
# Change 

Adds editorial notices to tally widget

ToDo:
- [ ] Change local host to scite-api before merge (requires config change for CORS)

# Demo / Testing

Have a look at the storybook `npm run storybook` to test the component out.

Basic unstyled notice:

<img width="692" alt="Screen Shot 2020-10-29 at 2 02 58 PM" src="https://user-images.githubusercontent.com/15069938/97607229-7c67fd00-19ef-11eb-9b40-9c5cb426d491.png">
