### PR TITLE
Fix citation type tally icon display

### DIFF
--- a/src/components/SectionTallyCount.js
+++ b/src/components/SectionTallyCount.js
@@ -15,7 +15,7 @@ const SectionTallyCount = ({ className, horizontal, type, count, showLabels = fa
   >
     <div
       className={
-        classNames(styles.iconCountWrapper, {
+        classNames(styles.sectionTallyIconCountWrapper, {
           [styles.expandedIconCount]: !showLabels
         })
       }

--- a/src/styles/Count.css
+++ b/src/styles/Count.css
@@ -16,6 +16,11 @@
 }
 
 .iconCountWrapper {
+    display: inline-block;
+    box-sizing: border-box;
+}
+
+.sectionTallyIconCountWrapper {
     display: flex;
     box-sizing: border-box;
 }
@@ -48,7 +53,7 @@
     width: auto;
 }
 
-.horizontal > .iconCountWrapper > .label {
+.horizontal > .sectionTallyIconCountWrapper > .label {
     width: auto;
     vertical-align: middle;
 }


### PR DESCRIPTION
In the past, `iconCountWrapper` was `display: inline-block`

I overloaded that wrapper for the `sectionTally` stuff and changed it to `flex`

But that breaks alignment on the old tally in horizontal mode

<img width="350" alt="Screen Shot 2022-04-27 at 3 01 37 PM" src="https://user-images.githubusercontent.com/14264791/165621491-62e77005-fcf2-4ea9-bb48-f9f3b0ea1e45.png">

So keep the old selector for the old tally
Add a new selector for the new tally with flex